### PR TITLE
Fix failing test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders main heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText(/Inputs & Controls/i);
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update App.test.js to check for the actual page heading

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684121005bb88328965334ed32c5b6dc