### PR TITLE
Implement password gate

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,48 @@ const formatPercent = (value, decimals = 1) => {
 
 // --- Main Application Component ---
 function App() {
+    // --- PASSWORD PROTECTION ---
+    const [authorized, setAuthorized] = useState(
+        localStorage.getItem('authorized') === 'true'
+    );
+    const [password, setPassword] = useState('');
+
+    const handlePasswordSubmit = (e) => {
+        e.preventDefault();
+        if (password === 'btcvegas2025') {
+            localStorage.setItem('authorized', 'true');
+            setAuthorized(true);
+        } else {
+            alert('Incorrect password');
+        }
+    };
+
+    if (!authorized) {
+        return (
+            <div style={{ padding: '40px', textAlign: 'center' }}>
+                <h2>Please Enter Password</h2>
+                <form onSubmit={handlePasswordSubmit} style={{ marginBottom: '20px' }}>
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        style={{ padding: '8px', fontSize: '16px' }}
+                    />
+                    <button type="submit" style={{ marginLeft: '10px', padding: '8px 12px' }}>
+                        Enter
+                    </button>
+                </form>
+                <a
+                    href="https://paypal.me/AlexanderBespalov440/20"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    <button>Request Password ($20 lifetime access)</button>
+                </a>
+            </div>
+        );
+    }
+
     // --- I. INPUTS & CONTROLS State ---
     // A. My Assets & Market View
     const [collateralInputMode, setCollateralInputMode] = useState('btc'); // 'btc' or 'usd'

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders main heading', () => {
+test('renders main heading when authorized', () => {
+  window.localStorage.setItem('authorized', 'true');
   render(<App />);
   const headingElement = screen.getByText(/Inputs & Controls/i);
   expect(headingElement).toBeInTheDocument();
+  window.localStorage.removeItem('authorized');
 });


### PR DESCRIPTION
## Summary
- add basic password protection to App component
- provide link to PayPal for password requests
- update test for new password gate

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684123782be483288daddbf44abe29e2